### PR TITLE
Update installation instructions and fixed all the boot errors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,9 @@ def architecture_config
   host_arch = `uname -m`.chomp
   case host_arch
   when 'x86_64', 'amd64'
-    { box_name: "ubuntu/focal64", provider_name: "virtualbox", disk_size: '50GB', required_plugins: ['vagrant-disksize'] }
+    { box_name: "ubuntu/noble64", provider_name: "virtualbox", disk_size: '50GB', required_plugins: ['vagrant-disksize'] }
   when 'aarch64', 'arm64'
-    { box_name: "bento/ubuntu-20.04", provider_name: "vmware_desktop", disk_size: nil, required_plugins: ['vagrant-vmware-desktop'] }
+    { box_name: "bento/ubuntu-24.04", provider_name: "vmware_desktop", disk_size: nil, required_plugins: ['vagrant-vmware-desktop'] }
   else
     raise "Unsupported architecture: #{host_arch}"
   end

--- a/deploy-latest.sh
+++ b/deploy-latest.sh
@@ -24,5 +24,4 @@ join_node() {
 }
 
 start_vagrant
-join_node
 

--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,13 @@ This repository offers a comprehensive setup for practicing for the CKA, CKAD, C
    - Apple Silicon
       - Install [VMware Fusion](https://www.vmware.com/products/fusion.html) (Download manually as the Homebrew cask is no longer available).
       - Install [Vagrant VMware Utility](https://developer.hashicorp.com/vagrant/docs/providers/vmware/vagrant-vmware-utility). Run `brew install vagrant-vmware-utility`
+      - Install Vagrant VMware Desktop plugin. Run `vagrant plugin install vagrant-vmware-desktop`
    - x86_AMD64
       - Install [VirtualBox](https://www.virtualbox.org/). Run `brew install --cask virtualbox`
 2. **Deployment**:
-   - Use provided script to deploy the Kubernetes cluster run `./deploy-latest.sh`.
+   - Use the provided script to deploy the Kubernetes cluster, run `./deploy-latest.sh`.
 3. **Clean Up**:
-   - Remove all VMs and resources run `./cleanup.sh` after practice sessions.
+   - To remove all VMs and resources, run `./cleanup.sh` after practice sessions.
 
 ## Usage
 - **Deploy Latest Kubernetes Cluster**: `./deploy-latest.sh`

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This repository offers a comprehensive setup for practicing for the CKA, CKAD, C
 
 ## Features
 - **Automated Kubernetes Cluster Setup**: Utilize Kubeadm to automate the creation of a Kubernetes cluster for CKA, CKAD, and CKS exam practice.
-- **Platform Compatibility**: Supports both x86_AMD64 with VirtualBox or Apple Silicon (M1/M2) with VMware Fusion.
+- **Platform Compatibility**: Supports both x86_AMD64 with VirtualBox or Apple Silicon (M-series) with VMware Fusion.
 - **Customizable Cluster Versions**: Easily deploy clusters with the latest or specific previous versions of Kubernetes.
 - **Resource Management**: Includes Vagrant Disksize plugin support for adjusting VM disk sizes as needed.
 - **Practice-Oriented Configuration**: Tailored configurations and security settings for realistic CKA, CKAD, CKS exams practice.
@@ -23,16 +23,16 @@ This repository offers a comprehensive setup for practicing for the CKA, CKAD, C
 1. **Installation**:
    - [Install Brew](https://brew.sh/)
    - Run `brew update` to refresh the list of available packages
-   - [Install Vagrant](https://www.vagrantup.com/docs/installation) Run `brew install hashicorp-vagrant`
+   - [Install Vagrant](https://www.vagrantup.com/docs/installation) Run `brew tap hashicorp/tap && brew install hashicorp/tap/hashicorp-vagrant`
    - [Vagrant Disksize plugin](https://github.com/sprotheroe/vagrant-disksize). Run `vagrant plugin install vagrant-disksize`
    - Apple Silicon
-      - Install [VMware Fusion](https://www.vmware.com/products/fusion.html). Run `brew install --cask vmware-fusion`
-      - Install [Vagrant VMware Utility](https://developer.hashicorp.com/vagrant/docs/providers/vmware/vagrant-vmware-utility). Run `brew upgrade vagrant-vmware-utility`
+      - Install [VMware Fusion](https://www.vmware.com/products/fusion.html) (Download manually as the Homebrew cask is no longer available).
+      - Install [Vagrant VMware Utility](https://developer.hashicorp.com/vagrant/docs/providers/vmware/vagrant-vmware-utility). Run `brew install vagrant-vmware-utility`
    - x86_AMD64
       - Install [VirtualBox](https://www.virtualbox.org/). Run `brew install --cask virtualbox`
-3. **Deployment**:
+2. **Deployment**:
    - Use provided script to deploy the Kubernetes cluster run `./deploy-latest.sh`.
-5. **Clean Up**:
+3. **Clean Up**:
    - Remove all VMs and resources run `./cleanup.sh` after practice sessions.
 
 ## Usage
@@ -42,7 +42,7 @@ This repository offers a comprehensive setup for practicing for the CKA, CKAD, C
 
 ## Supported Platforms
 - x86_AMD64 (VirtualBox)
-- Apple Silicon (M1/M2 with VMware Fusion)
+- Apple Silicon (M-series with VMware Fusion)
 
 ## License
 This project is licensed under the MIT License. See LICENSE.md for more details.

--- a/scripts/install-cks-master.sh
+++ b/scripts/install-cks-master.sh
@@ -6,7 +6,7 @@ INSTALL_FALCO=true
 download_and_customize_script() {
     local url="https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/${INSTALL_SCRIPT}/install_master.sh"
     local script
-    script=$(curl -ssL "$url")
+    script=$(curl -fssL --retry 5 --retry-delay 10 "$url")
 
     script=$(echo "$script" | set_shebang)
     script=$(echo "$script" | adjust_architecture)

--- a/scripts/install-cks-master.sh
+++ b/scripts/install-cks-master.sh
@@ -13,9 +13,19 @@ download_and_customize_script() {
     script=$(echo "$script" | customize_kubeadm_init)
     [[ "$INSTALL_TRIVY" == "true" ]] && script=$(echo "$script" | add_trivy)
     [[ "$INSTALL_FALCO" == "true" ]] && script=$(echo "$script" | add_falco)
+    script=$(echo "$script" | fix_weave_image)
     script=$(echo "$script" | fix_rm_usage)
+    script=$(echo "$script" | fix_pod_network_cidr)
 
     echo "$script"
+}
+
+fix_weave_image() {
+    sed 's@kubectl apply -f https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/weave.yaml@curl -sL https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/weave.yaml | sed -e "s/:latest/:2.8.1/g" -e "s|192.168.0.0/16|10.50.0.0/16|g" | kubectl apply -f -@g'
+}
+
+fix_pod_network_cidr() {
+    sed '/kubeadm init/s|192.168.0.0/16|10.50.0.0/16|g'
 }
 
 set_shebang() {
@@ -62,7 +72,7 @@ add_falco() {
 }
 
 fix_rm_usage() {
-    sed 's/\brm \([^ ]\)/rm -f \1/g'
+    sed 's/^\([[:space:]]*\)rm /\1rm -f /g'
 }
 
 bash -x <( \

--- a/scripts/install-cks-worker.sh
+++ b/scripts/install-cks-worker.sh
@@ -6,7 +6,7 @@ INSTALL_FALCO=true
 download_and_customize_script() {
     local url="https://raw.githubusercontent.com/killer-sh/cks-course-environment/master/cluster-setup/${INSTALL_SCRIPT}/install_worker.sh"
     local script
-    script=$(curl -s "$url")
+    script=$(curl -fssL --retry 5 --retry-delay 10 "$url")
 
     script=$(echo "$script" | set_shebang)
     script=$(echo "$script" | adjust_architecture)

--- a/scripts/install-cks-worker.sh
+++ b/scripts/install-cks-worker.sh
@@ -51,7 +51,7 @@ add_falco() {
 }
 
 fix_rm_usage() {
-    sed 's/\brm \([^ ]\)/rm -f \1/g'
+    sed 's/^\([[:space:]]*\)rm /\1rm -f /g'
 }
 
 bash -x <( \

--- a/scripts/setup-etc-hosts.sh
+++ b/scripts/setup-etc-hosts.sh
@@ -2,3 +2,15 @@
 set -ex
 
 sed -i -e "s/^.*${HOSTNAME}.*/${1} ${HOSTNAME} ${HOSTNAME}.local/" /etc/hosts
+
+echo "Forcing time synchronization..."
+timedatectl set-ntp true
+systemctl restart systemd-timesyncd
+
+echo "Waiting for time synchronization to complete..."
+timeout 60 bash -c 'while ! timedatectl timesync-status | grep -E -q "Packet count: [1-9]"; do sleep 1; done' || true
+
+echo "Writing corrected time to hardware clock..."
+apt-get update -qq
+apt-get install -y -qq util-linux-extra > /dev/null 2>&1
+hwclock --systohc --utc


### PR DESCRIPTION
**Documentation & Dependency Updates:**
- Replaced the deprecated `hashicorp-vagrant` cask with the official tap.
- Added instructions for manual download of VMware Fusion.
- Updated "Apple Silicon (M1/M2)" references to "(M-series)".
- Added the missing `vagrant-vmware-desktop` plugin requirement.

**OS Upgrade & Tooling Fixes:**
- Upgraded the Vagrant boxes from Ubuntu 20.04 (`focal64`) to Ubuntu 24.04 (`noble64` / `bento/ubuntu-24.04`) to satisfy the latest dependencies required by the `killer.sh` cluster-setup scripts.
- Fixed a regex bug in the provisioning scripts where replacing `rm` with `rm -f` was accidentally corrupting `crictl rm` commands.

**Networking & ARM64 Compatibility Fixes:**
- **Fixed Weave Net on ARM64:** Intercepted the applied `weave.yaml` to dynamically replace the broken `weaveworks/weave-kube:latest` Docker Hub image (which mistakenly contained an `amd64` binary) with the fully compatible `2.8.1` version.
- **Resolved IP Overlap Crash:** Modified the pod network CIDR from `192.168.0.0/16` to `10.50.0.0/16` in both `kubeadm init` and Weave's `IPALLOC_RANGE`. This completely resolves the `CrashLoopBackOff` caused by Weave overlapping with Vagrant's default `192.168.5.x` private network adapter.

**Worker Node Provisioning:**
- Removed the redundant, hardcoded `./join-node.sh` command from `deploy-latest.sh`, which was causing `preflight` execution errors because Vagrant was already natively joining the worker to the cluster via its `node.trigger.after :up` hook.